### PR TITLE
ms5611 fix

### DIFF
--- a/esphome/components/ms5611/ms5611.cpp
+++ b/esphome/components/ms5611/ms5611.cpp
@@ -19,7 +19,7 @@ void MS5611Component::setup() {
     this->mark_failed();
     return;
   }
-  delay(100);  // NOLINT
+  delay(3);  // NOLINT trug, change from 100 to 3
   for (uint8_t offset = 0; offset < 6; offset++) {
     if (!this->read_byte_16(MS5611_CMD_READ_PROM + (offset * 2), &this->prom_[offset])) {
       this->mark_failed();


### PR DESCRIPTION
## Description:
Originally posted info here:
https://community.home-assistant.io/t/esphome-ms5611-issue/164240/2

I reduced the delay between reset and prom read commands from 100ms to 3ms, to match working ms5xxx.cpp library.

**Related issue (if applicable):** 

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

Checklist isn't filled out, because I'm a newb who can't test this out on his ha instance (compiling overwrites the src directories without a dev enviro). Since it's just the delay for reading prom, I don't think much could go wrong here.